### PR TITLE
Fix upload and edit book

### DIFF
--- a/books/forms.py
+++ b/books/forms.py
@@ -36,7 +36,8 @@ class BookForm(ModelForm):
         """
         instance = super(BookForm, self).save(commit=False)
         book_file = self.cleaned_data['book_file']
-        instance.mimetype = book_file.content_type
+        if instance.mimetype is None:
+            instance.mimetype = book_file.content_type
         if commit:
             instance.save()
         return instance

--- a/books/models.py
+++ b/books/models.py
@@ -108,10 +108,9 @@ class Book(models.Model):
     cover_img = models.FileField(blank=True, upload_to='covers')
 
     def save(self, *args, **kwargs):
-        if self.file_sha256sum: # we already have the sha256_sum
-            return
-        self.file_sha256sum = sha256_sum(self.book_file)
-        super(Book, self).save()
+        if not self.file_sha256sum:
+            self.file_sha256sum = sha256_sum(self.book_file)
+        super(Book, self).save(*args, **kwargs)
 
     class Meta:
         ordering = ('-time_added',)


### PR DESCRIPTION
This PR includes:
- fix sha256 calculation
- book model save() method invoke parent with argument always
- exclude file_sha256sum field from BookFom
- ignore mimetype when editing in BookForm
