### PR TITLE
Update version of django-sendfile to 0.3.6

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 Django==1.4.5
 django-tagging==0.3.1
-django-sendfile==0.3.0
+django-sendfile==0.3.6
 MySQL-python>=1.2.3
 # hope to replace django-tagging with django-taggit
 git+git://github.com/FinalsClub/django-taggit.git


### PR DESCRIPTION
The version 0.3.0 give a error when trying to use pip to install.