### PR TITLE
Enable user comments

### DIFF
--- a/books/app_settings.py
+++ b/books/app_settings.py
@@ -30,3 +30,7 @@ BOOKS_STATICS_VIA_DJANGO = getattr(settings, 'BOOKS_STATICS_VIA_DJANGO', False)
 # This needs to match the published status
 
 BOOK_PUBLISHED = getattr(settings, 'BOOK_PUBLISHED', 1)
+
+# Features
+
+ALLOW_USER_COMMENTS = False

--- a/books/models.py
+++ b/books/models.py
@@ -122,3 +122,16 @@ class Book(models.Model):
     @models.permalink
     def get_absolute_url(self):
         return ('pathagar.books.views.book_detail', [self.pk])
+
+
+class Comment(models.Model):
+    comment = models.CharField(max_length=200, blank=False)
+    user_name = models.CharField(max_length=30, blank=False)
+    book_id = models.ForeignKey(Book)
+
+    class Meta:
+        verbose_name = "Comment"
+        verbose_name_plural = "Comments"
+
+    def __unicode__(self):
+        return self.comment

--- a/templates/books/book_detail.html
+++ b/templates/books/book_detail.html
@@ -62,6 +62,68 @@
 </p>
 </div>
 <hr>
+
+{% if allow_user_comments %}
+<div class="span-16">
+<label>Readers comments:</label>
+</div>
+<hr class="space">
+{% for comment in comments_list %}
+<div class="span-16">{{ comment.comment }} <i> {{ comment.user_name }}</i></div>
+<hr class="space">
+{%  endfor %}
+
+    <script type="text/javascript">
+        function validateForm(form) {
+            if (form['user_name'].value == '') {
+                alert('Please, write your name');
+                form['user_name'].focus();
+                return false;
+            }
+            if (form['comment'].value == '') {
+                alert('Please, write your comment');
+                form['comment'].focus();
+                return false;
+            }
+            input_result = -1;
+            input_result = parseInt(form['result'].value);
+            if (input_result != {{ captcha_result }}) {
+                alert('Wrong value');
+                return false;
+            };
+            return true;
+        }
+    </script>
+
+<hr>
+
+<div class="span-16">
+<label>Add your comment:</label>
+</div>
+<hr class="space">
+
+    <form action="/add_comment/" method="post" name="add_comment"
+            onsubmit="return validateForm(this)">
+        <div class="span-4"><label>Your name:</label></div>
+        <input type="input" name="user_name">
+        <hr class="space">
+        <div class="span-4"><label>Your comment:</label></div>
+        <textarea name="comment" rows="4" cols="50" style="height:50px">
+        </textarea>
+        <hr class="space">
+
+        <div class="span-4"><label>The result of {{ simple_captcha }} is:</label></div>
+        <input type="input" name="result">
+        <input type="hidden" name="book_id" value="{{book.a_id}}">
+
+        <hr class="space">
+        {% csrf_token %}
+        <input type="submit" value="Add">
+    </form>
+
+</div>
+{% endif %}
+
 </div>
 
 <div class="span-6 last" id="sidebar">

--- a/urls.py
+++ b/urls.py
@@ -64,6 +64,9 @@ urlpatterns = patterns('',
     # Add language:
     (r'^add/dc_language|language/$', 'pathagar.books.views.add_language'),
 
+    # Add comment:
+    (r'^add_comment/$', 'pathagar.books.views.add_comment'),
+
     # Auth login and logout:
     (r'^accounts/login/$', 'django.contrib.auth.views.login'),
     (r'^accounts/logout/$', 'django.contrib.auth.views.logout'),


### PR DESCRIPTION
This feature is enabled modifing ALLOW_USER_COMMENTS in app_settings.py
and is disabled by default.
When is enabled, show a form to add comments from the users in
the detail of every book. The user do not need to be logued, then
a very simple captcha is added.