### PR TITLE
Add comments using django framework

### DIFF
--- a/books/app_settings.py
+++ b/books/app_settings.py
@@ -30,3 +30,7 @@ BOOKS_STATICS_VIA_DJANGO = getattr(settings, 'BOOKS_STATICS_VIA_DJANGO', False)
 # This needs to match the published status
 
 BOOK_PUBLISHED = getattr(settings, 'BOOK_PUBLISHED', 1)
+
+# Features
+
+ALLOW_USER_COMMENTS = False

--- a/books/views.py
+++ b/books/views.py
@@ -53,7 +53,7 @@ from opds import generate_root_catalog
 from opds import generate_tags_catalog
 from opds import generate_taggroups_catalog
 
-from pathagar.books.app_settings import BOOK_PUBLISHED
+from pathagar.books.app_settings import BOOK_PUBLISHED, ALLOW_USER_COMMENTS
 
 
 @login_required
@@ -96,6 +96,7 @@ def book_detail(request, book_id):
         queryset = Book.objects.all(),
         object_id = book_id,
         template_object_name = 'book',
+        extra_context = {'allow_user_comments': ALLOW_USER_COMMENTS}
     )
 
 def download_book(request, book_id):

--- a/settings.py
+++ b/settings.py
@@ -93,5 +93,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'tagging', # TODO old
     'taggit',
+    'django.contrib.comments',
     'pathagar.books'
 )

--- a/templates/books/book_detail.html
+++ b/templates/books/book_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load tagging_tags %}
+{% load comments %}
 
 {% block title %}{{ book.a_title }} :: Pathagar Book Server{% endblock %}
 
@@ -62,6 +63,48 @@
 </p>
 </div>
 <hr>
+{% if allow_user_comments %}
+
+<div class="span-16">
+<label>Readers comments:</label>
+</div>
+<hr class="space">
+
+{% get_comment_list for book as comment_list %}
+{% for comment in comment_list %}
+<div class="span-16"><b> {{ comment.user_name }} said: </b>{{ comment.comment }}</div>
+<hr class="space">
+{% endfor %}
+
+<hr>
+
+<div class="span-16">
+<label>Add your comment:</label>
+</div>
+
+{% get_comment_form for book as form %}
+<form action="{% comment_form_target %}" method="post">
+{% csrf_token %}
+
+{{ form.content_type }}
+{{ form.object_pk }}
+{{ form.timestamp }}
+{{ form.security_hash }}
+<input type="hidden" name="next" value="{% url pathagar.books.views.book_detail book.pk %}" />
+
+<div class="span-4"><label for="id_your_name">Your name:</label></div>
+{{ form.name }}
+<hr class="space">
+
+<div class="span-4"><label for="id_comment">Your comment:</label></div>
+{{ form.comment }}
+<hr class="space">
+
+<input type="submit" name="submit" value="Post">
+</form>
+
+
+{% endif %}
 </div>
 
 <div class="span-6 last" id="sidebar">

--- a/urls.py
+++ b/urls.py
@@ -61,6 +61,9 @@ urlpatterns = patterns('',
     (r'^book/(?P<book_id>\d+)/remove$', 'pathagar.books.views.remove_book'),
     (r'^book/(?P<book_id>\d+)/download$', 'pathagar.books.views.download_book'),
 
+    # Comments
+    (r'^comments/', include('django.contrib.comments.urls')),
+
     # Add language:
     (r'^add/dc_language|language/$', 'pathagar.books.views.add_language'),
 


### PR DESCRIPTION
This feature is enabled modifing ALLOW_USER_COMMENTS in app_settings.py
and is disabled by default.
When is enabled, show a form to add comments from the users in
the detail of every book. The user do not need to be logued.
It's implemented using the django comments framework [1]

[1] https://docs.djangoproject.com/en/1.4/ref/contrib/comments/