### PR TITLE
Add a config to allow non logued users to add books

### DIFF
--- a/books/views.py
+++ b/books/views.py
@@ -56,8 +56,12 @@ from pathagar.books.app_settings import BOOK_PUBLISHED
 def add_language(request):
     return handlePopAdd(request, AddLanguageForm, 'language')
 
-@login_required
 def add_book(request):
+    context_instance = RequestContext(request)
+    user = resolve_variable('user', context_instance)
+    if not settings.ALLOW_PUBLIC_ADD_BOOKS and not user.is_authenticated():
+        return redirect('/accounts/login/?next=/book/add')
+
     extra_context = {'action': 'add'}
     return create_object(
         request,
@@ -196,6 +200,7 @@ def _book_list(request, queryset, qtype=None, list_by='latest', **kwargs):
         'search_title': search_title,
         'search_author': search_author, 'list_by': list_by,
         'qstring': qstring,
+        'allow_public_add_book': settings.ALLOW_PUBLIC_ADD_BOOKS
     })
     return render_to_response(
         'books/book_list.html',

--- a/settings.py
+++ b/settings.py
@@ -20,6 +20,9 @@ BOOKS_PER_PAGE = 20 # Number of books shown per page in the OPDS
 
 BOOKS_STATICS_VIA_DJANGO = True
 
+# Allow non logued users to upload books
+ALLOW_PUBLIC_ADD_BOOKS = False
+
 # sendfile settings:
 
 SENDFILE_BACKEND = 'sendfile.backends.development'

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,6 +94,9 @@ method="get">
 <a href="{% url pathagar.books.views.add_book %}">Add Book</a>&nbsp;&nbsp;
 <a href="{% url django.contrib.auth.views.logout %}?next=/">Log Out</a>
 {% else %}
+{% if allow_public_add_book %}
+<a href="{% url pathagar.books.views.add_book %}">Add Book</a>&nbsp;&nbsp;
+{% endif %}
 <a href="{% url django.contrib.auth.views.login %}?next=/">Log In</a>
 {% endif %}
 </div> 


### PR DESCRIPTION
A setting ALLOW_PUBLIC_ADD_BOOKS is added (by default False)
If is True, non logued users can upload books.
In the case of Pathagar instances running in school servers
this allow the kids to upload books without need create users.
Admins can edit/remove books if needed.