### PR TITLE
fixes django-taggit using standard packageing

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -2,5 +2,4 @@ Django==1.4.5
 django-tagging==0.3.1
 django-sendfile==0.3.6
 MySQL-python>=1.2.3
-# hope to replace django-tagging with django-taggit
-git+git://github.com/FinalsClub/django-taggit.git
+django-taggit==0.14.0


### PR DESCRIPTION
We'd been using an old fork of django-taggit of mine for reasons I forget.  I tried using the latest (2015) release of the standard taggit package and it seems to work fine.