### PR TITLE
Book form: allow configure the default status for a book

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -19,6 +19,7 @@ import os
 
 from django.db import models
 from django.core.files import File
+from django.conf import settings
 
 from hashlib import sha256
 
@@ -95,7 +96,8 @@ class Book(models.Model):
     tags = TaggableManager(blank=True)
     downloads = models.IntegerField(default=0)
     a_id = UUIDField('atom:id')
-    a_status = models.ForeignKey(Status, blank=False, null=False)
+    a_status = models.ForeignKey(Status, blank=False, null=False,
+                                 default=settings.DEFAULT_BOOK_STATUS)
     a_title = models.CharField('atom:title', max_length=200)
     a_author = models.CharField('atom:author', max_length=200)
     a_updated = models.DateTimeField('atom:updated', auto_now=True)

--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,7 @@ BOOKS_PER_PAGE = 20 # Number of books shown per page in the OPDS
                     # catalogs and in the HTML pages.
 
 BOOKS_STATICS_VIA_DJANGO = True
+DEFAULT_BOOK_STATUS = 'Published'
 
 # Allow non logued users to upload books
 ALLOW_PUBLIC_ADD_BOOKS = False


### PR DESCRIPTION
In deployments where end users can add books, set the status
can be a annoyance. Allow set the status in the settings.py file,
and set the default value to 'Published'