### PR TITLE
Allow override of settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ database.db
 *pyc
 staticfiles/
 static_media/books
+local_settings.py

--- a/README.mkd
+++ b/README.mkd
@@ -115,8 +115,8 @@ In Fedora
     sudo pip install -r requirements.pip
 
 
-* In the Pathagar folder edit settings.py to suite your needs and
-  environment.
+* In the Pathagar folder, copy `local_settings.example.py` to
+  `local_settings.py` and edit it to suite your needs and environment.
 
 * In the Pathagar folder, run
 

--- a/local_settings.example.py
+++ b/local_settings.example.py
@@ -1,0 +1,5 @@
+# Copy this file to local_settings.py, then customize settings to your
+# setup.
+
+DEBUG = True
+TIME_ZONE = 'America/Los_Angeles'

--- a/settings.py
+++ b/settings.py
@@ -102,3 +102,9 @@ INSTALLED_APPS = (
     'django.contrib.comments',
     'pathagar.books'
 )
+
+
+try:
+    from local_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
Copy the example `local_settings.example.py` to `local_settings.py` to easily
override settings for development or production.