### PR TITLE
Use urlresolvers to determine route

### DIFF
--- a/books/views.py
+++ b/books/views.py
@@ -18,6 +18,7 @@
 import os
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.http import Http404
 from django.shortcuts import render_to_response
@@ -61,7 +62,8 @@ def add_book(request):
     context_instance = RequestContext(request)
     user = resolve_variable('user', context_instance)
     if not settings.ALLOW_PUBLIC_ADD_BOOKS and not user.is_authenticated():
-        return redirect('/accounts/login/?next=/book/add')
+        next = reverse('pathagar.books.views.add_book')
+        return redirect('/accounts/login/?next=%s' % next)
 
     extra_context = {'action': 'add'}
     return create_object(

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,14 +92,14 @@ method="get">
 {% if user.is_authenticated %}
 <span>Welcome, {{ user.username }}&nbsp;&nbsp;</span>
 <a href="{% url pathagar.books.views.add_book %}">Add Book</a>&nbsp;&nbsp;
-<a href="{% url django.contrib.auth.views.logout %}?next=/">Log Out</a>
+<a href="{% url django.contrib.auth.views.logout %}?next={% url pathagar.books.views.home %}">Log Out</a>
 {% else %}
 {% if allow_public_add_book %}
 <a href="{% url pathagar.books.views.add_book %}">Add Book</a>&nbsp;&nbsp;
 {% endif %}
-<a href="{% url django.contrib.auth.views.login %}?next=/">Log In</a>
+<a href="{% url django.contrib.auth.views.login %}?next={% url pathagar.books.views.home %}">Log In</a>
 {% endif %}
-</div> 
+</div>
 
 {% block feed_link %}{% endblock %}
 


### PR DESCRIPTION
If Pathagar is configured to serve at a non-root path, we need to build the
`next` redirects properly. Use urlresolvers to determine the URLs.

Fixes https://github.com/PathagarBooks/pathagar/issues/81