### PR TITLE
Bugfixes for fetch_ia_item and addbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 database.db
 *pyc
 staticfiles/
-static_media/books
+static_media/
 local_settings.py

--- a/README.mkd
+++ b/README.mkd
@@ -57,20 +57,54 @@ files), through the command:
 Pathagar runs on the python web app framework Django.  It is known to work in Django 1.3 and 1.4.
 
 
-Format of CSV file
-==================
+## Loading content
+
+Once installed, Pathagar contains no books. You can upload individual books
+through the UI or you can bulk load them by following the instructions below.
+
+
+### From Internet Archive
+
+You can download book files from Internet Archive. First you need to create
+a user and a bookmarks list. Once created, you'll fetch the book files on your
+bookmarks list with the `fetch_ia_item` command.
+
+    python manage.py fetch_ia_item --username=<your-username> --out=books.json
+
+This can take a while depending on your internet connection and how many books
+you have on your bookmarks list. You might want to go grab a coffee and take
+a stretch break.
+
+Once complete, you'll have a `books.json` file which you can use with the
+`addbooks` command.
+
+    python manage.py addbooks --json books.json
+
+Learn more about the `addbooks` command below.
+
+
+### addbooks command
+
+If you have your books already with metadata described in a file, use the
+`addbooks` command to import them into Pathagar.
+
+
+#### CSV format
 
 To add books from a CSV file:
 
     python manage.py addbooks books.csv
 
 The format of the CSV file is like:
-  "Path to ebook file","Title","Author","Description"
+
+```
+"Path to ebook file","Title","Author","Description"
+```
 
 If you need to add more fields, please use the JSON file.
 
-Format of JSON file
-===================
+
+#### JSON format
 
 To add books from a JSON file:
 
@@ -92,6 +126,7 @@ The format of the JSON file is like::
     ]
 
 You can add more fields.  Please refer to the Book model.
+
 
 Dependencies
 ============

--- a/books/management/commands/addbooks.py
+++ b/books/management/commands/addbooks.py
@@ -126,6 +126,9 @@ class Command(BaseCommand):
                 if str(e) == "column file_sha256sum is not unique":
                     print "The book (", d['book_file'], ") was not saved " \
                         "because the file already exists in the database."
+                elif "duplicate key value violates unique constraint" in str(e):
+                    print "The book (", d['book_file'], ") was not saved " \
+                        "because the file already exists in the database."
                 elif str(e) == "UNIQUE constraint failed: books_book.file_sha256sum":
                     if 'book_file' not in d:
                         print d

--- a/books/management/commands/addbooks.py
+++ b/books/management/commands/addbooks.py
@@ -130,7 +130,7 @@ class Command(BaseCommand):
 
                 with transaction.commit_on_success():
                     book.save() # must save item to generate Book.id before creating tags
-                    [book.tags.add(tag) for tag in tags]
+                    [book.tags.add(tag) for tag in tags if tag]
                     book.save()  # save again after tags are generated
                     stats['imported'] += 1
             except ValidationError as e:

--- a/books/management/commands/addbooks.py
+++ b/books/management/commands/addbooks.py
@@ -139,7 +139,6 @@ class Command(BaseCommand):
             except Exception as e:
                 stats['errors'] += 1
                 # Likely a bug
-                book_file = d.get('book_file', 'unknown')
                 logger.warn('Error adding book title="%s": %s' % (
                     book.a_title, e))
 

--- a/books/management/commands/fetch_ia_item.py
+++ b/books/management/commands/fetch_ia_item.py
@@ -8,7 +8,7 @@ This script will download all of an user's bookmarked items from archive.org.
 
 from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
-import settings
+from django.conf import settings
 
 import re
 import os

--- a/books/management/commands/fetch_ia_item.py
+++ b/books/management/commands/fetch_ia_item.py
@@ -193,6 +193,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if not options['username']:
            raise CommandError("Option '--username ...' must be specified.")
+
+        if not os.path.exists(download_directory):
+            os.mkdir(download_directory, 0o755)
+
         bookmarks = load_user_bookmarks(options['username'])
         pathagar_books = []
         for item in bookmarks:

--- a/books/models.py
+++ b/books/models.py
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import os
+import os.path
 
 from django.db import models
 from django.core.files import File
@@ -127,7 +128,7 @@ class Book(models.Model):
                 # get the cover path from the epub file
                 epub_file = Epub(self.book_file)
                 cover_path = epub_file.get_cover_image_path()
-                if cover_path is not None:
+                if cover_path is not None and os.path.exists(cover_path):
                     cover_file = File(open(cover_path))
                     self.cover_img.save(os.path.basename(cover_path),
                                         cover_file)


### PR DESCRIPTION
fetch_ia_item allows downloads book files from Internet Archive and produces a json file that can then be used to import the books into Pathagar. Unfortunately, the job wasn't handling the metadata very well. Not all books are guaranteed to have all fields.

Another issue with `addbooks` is how it detects duplicate books -- it doesn't. It tries to save them and waits for an error. Based on the error text, it could determine if the book save failed due to a uniqueness constraint. Unfortunately, the error text is different depending on which backend you use. Overall, not a great strategy.

The goal with this PR is to just get things into a working state so that users have some method to bulk add books.