### PR TITLE
Disable the sites framework

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -51,8 +51,6 @@ TIME_ZONE = 'America/Chicago'
 
 LANGUAGE_CODE = 'en-us'
 
-SITE_ID = 1
-
 USE_I18N = True
 
 MEDIA_ROOT = os.path.join(CUR_DIR, 'static_media')
@@ -94,7 +92,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'tagging', # TODO old


### PR DESCRIPTION
We're not using the sites framework, so it's just something extra that could be
accidentally misconfigured.

We had a situation where syncdb did not complete properly and pathagar could not be loaded because the site models didn't exist.